### PR TITLE
main.py: remove --autounmask=n restriction

### DIFF
--- a/src/pkg_testing_tool/main.py
+++ b/src/pkg_testing_tool/main.py
@@ -142,7 +142,6 @@ def run_testing(job, args):
     emerge_cmdline = [
         'emerge',
         '--verbose', 'y',
-        '--autounmask', 'n',
         '--usepkg-exclude', job['cp'],
         '--deep', '--backtrack', '300',
     ]


### PR DESCRIPTION
 - this is the most popular point of failure when using pkg-testing-tools to
   test packages. It fails too often due to different USE flag combinations
   requiring USE flags enabled/disabled on dependencies. I can't control
   autounmasking via make.conf or package.env when pkg-testing-tool itself
   blocks it with emerge command.

I'd also like to note I run to this error almost everyday when testing packages. I don't understand why it's disabled in *pkg-testing-tool* when having `--autounmask=y --autounmask-write --autounmask-continue --autounmask-use=y` makes life that much easier.