### PR TITLE
Add option to append parameters to emerge

### DIFF
--- a/src/pkg_testing_tool/main.py
+++ b/src/pkg_testing_tool/main.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 from contextlib import ExitStack
 from tempfile import NamedTemporaryFile
+import shlex
 
 import portage
 
@@ -87,6 +88,11 @@ def process_args():
         help="Extra /etc/portage/env/ file name, to be used while testing packages. Can be passed multile times."
     )
 
+    optional.add_argument(
+        '--append-emerge', action='store', type=str, required=False,
+        help="Append flags or parameters to the actual emerge call."
+    )
+
     args, extra_args = parser.parse_known_args()
     if extra_args:
         if extra_args[0] != '--':
@@ -146,6 +152,8 @@ def run_testing(job, args):
         '--usepkg-exclude', job['cp'],
         '--deep', '--backtrack', '300',
     ]
+    if args.append_emerge:
+        emerge_cmdline += shlex.split(args.append_emerge)
 
     if args.binpkg:
         emerge_cmdline.append('--usepkg')


### PR DESCRIPTION
Just an option to add parameters to the `emerge_cmdline` would be great.

This could also address PR: https://github.com/slashbeast/pkg-testing-tools/pull/10 allowing users to pass `--autounmask=y --autounmask-write --autounmask-continue --autounmask-use=y` instead of hardcode patching it, like in this issue https://github.com/slashbeast/pkg-testing-tools/issues/5.